### PR TITLE
Add a dev GitHub Page from the dev branch

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,7 +2,7 @@ name: Deploy to GitHub Pages
 
 on:
   push:
-    branches: [ "master" ]
+    branches: [ "master", "dev" ]
   workflow_dispatch:
 
 permissions:
@@ -42,5 +42,17 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4
+
+  deploy-dev:
+    if: github.ref == 'refs/heads/dev'
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages-dev
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages (Dev)
         id: deployment
         uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -44,3 +44,13 @@ ArcGIS Auth token: `https://columbia.maps.arcgis.com/home/item.html?id=a20ff9428
 2. Los Angeles: transportation
 3. Copenhagen: cloudburst
 4. Mexico City: rainwater
+
+## Deployment
+
+### Production Deployment
+
+The production GitHub Page is deployed from the `master` branch. To deploy the production build, push your changes to the `master` branch. The GitHub Actions workflow will automatically build and deploy the application to the production GitHub Page.
+
+### Development Deployment
+
+The development GitHub Page is deployed from the `dev` branch. To deploy the development build, push your changes to the `dev` branch. The GitHub Actions workflow will automatically build and deploy the application to the development GitHub Page.

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,7 +1,7 @@
 import { defineConfig } from "vite";
 
-const config = {
-  base: '/uccrn-atlas-demo/',  // Changed from '/ipcc-apps-uccrn-atlas-demo/'
+const productionConfig = {
+  base: '/uccrn-atlas-demo/',
   build: {
     chunkSizeWarningLimit: 2000
   },
@@ -10,4 +10,20 @@ const config = {
   }
 };
 
-export default defineConfig(config);
+const developmentConfig = {
+  base: '/uccrn-atlas-demo-dev/',
+  build: {
+    chunkSizeWarningLimit: 2000
+  },
+  server: {
+    open: true
+  }
+};
+
+export default defineConfig(({ mode }) => {
+  if (mode === 'development') {
+    return developmentConfig;
+  } else {
+    return productionConfig;
+  }
+});


### PR DESCRIPTION
Add deployment configuration for development GitHub Page from the `dev` branch.

* **vite.config.js**
  - Add separate configurations for production and development builds.
  - Set base URL for production build to `/uccrn-atlas-demo/`.
  - Set base URL for development build to `/uccrn-atlas-demo-dev/`.

* **.github/workflows/deploy.yml**
  - Update workflow to deploy on pushes to both `master` and `dev` branches.
  - Add a new job for the `dev` branch deployment.

* **README.md**
  - Add instructions for deploying a development GitHub Page from the `dev` branch.
  - Include details for both production and development deployments.

