### PR TITLE
Update deployment URLs for master and dev branches

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -38,21 +38,9 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
+      name: ${{ github.ref == 'refs/heads/master' && 'github-pages' || 'github-pages-dev' }}
+      url: ${{ github.ref == 'refs/heads/master' && 'https://<username>.github.io/uccrn-atlas-demo/' || 'https://<username>.github.io/uccrn-atlas-demo-dev/' }}
     steps:
       - name: Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@v4
-
-  deploy-dev:
-    if: github.ref == 'refs/heads/dev'
-    needs: build
-    runs-on: ubuntu-latest
-    environment:
-      name: github-pages-dev
-      url: ${{ steps.deployment.outputs.page_url }}
-    steps:
-      - name: Deploy to GitHub Pages (Dev)
         id: deployment
         uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -49,8 +49,8 @@ ArcGIS Auth token: `https://columbia.maps.arcgis.com/home/item.html?id=a20ff9428
 
 ### Production Deployment
 
-The production GitHub Page is deployed from the `master` branch. To deploy the production build, push your changes to the `master` branch. The GitHub Actions workflow will automatically build and deploy the application to the production GitHub Page.
+The production GitHub Page is deployed from the `master` branch. To deploy the production build, push your changes to the `master` branch. The GitHub Actions workflow will automatically build and deploy the application to the production GitHub Page at `https://<username>.github.io/uccrn-atlas-demo/`.
 
 ### Development Deployment
 
-The development GitHub Page is deployed from the `dev` branch. To deploy the development build, push your changes to the `dev` branch. The GitHub Actions workflow will automatically build and deploy the application to the development GitHub Page.
+The development GitHub Page is deployed from the `dev` branch. To deploy the development build, push your changes to the `dev` branch. The GitHub Actions workflow will automatically build and deploy the application to the development GitHub Page at `https://<username>.github.io/uccrn-atlas-demo-dev/`.


### PR DESCRIPTION
Update the GitHub Actions workflow and README to handle separate URLs for production and development deployments.

* **README.md**
  - Update the "Production Deployment" section to specify the URL for the production GitHub Page.
  - Update the "Development Deployment" section to specify the URL for the development GitHub Page.

* **.github/workflows/deploy.yml**
  - Update the `deploy` job to handle both `master` and `dev` branches.
  - Set different base URLs for `master` and `dev` branches in the `deploy` job.
  - Remove the `deploy-dev` job as it is no longer needed.

